### PR TITLE
Add entity

### DIFF
--- a/muggy/CMakeLists.txt
+++ b/muggy/CMakeLists.txt
@@ -106,6 +106,11 @@ target_link_libraries ( ${PROJECT_NAME}
 #                        PRIVATE GLEW 
 )
 
+# Add compile defines such as DEBUG_BUILD etc
+target_compile_definitions( muggy 
+                            PUBLIC  $<$<CONFIG:Debug>:DEBUG_BUILD>
+)
+
 if ( WIN32 )
     # Add a suffix to the import library to avoid naming conflicts
     set_target_properties(muggy PROPERTIES IMPORT_SUFFIX "dll.lib")

--- a/muggy/code/components/componentsCommon.h
+++ b/muggy/code/components/componentsCommon.h
@@ -1,0 +1,21 @@
+//********************************************************************
+//  File:    componentsCommon.h
+//  Date:    Fri, 24 Nov 2023: 20:47
+//  Version: 
+//  Author:  klek
+//  Notes:   
+//********************************************************************
+
+#if !defined(COMPONENTS_COMMON_H)
+#define COMPONENTS_COMMON_H
+
+#include "../common/common.h"
+#include "../common/id.h"
+
+// Including the class definitons from the engineAPI
+#include "../../engineAPI/gameEntity.h"
+#include "../../engineAPI/componentTransform.h"
+
+
+
+#endif

--- a/muggy/code/components/entity.cpp
+++ b/muggy/code/components/entity.cpp
@@ -1,0 +1,118 @@
+//********************************************************************
+//  File:    entity.cpp
+//  Date:    Fri, 24 Nov 2023: 20:49
+//  Version: 
+//  Author:  klek
+//  Notes:   
+//********************************************************************
+
+#include "entity.h"
+#include "transform.h"
+
+namespace muggy::game_entity
+{
+    namespace 
+    {
+        utils::vector<transform::component> transforms;
+        
+        utils::vector<id::generation_type>  generations;
+        utils::deque<entity_id>             freeIds;
+    } // namespace anonymous
+    
+    entity createGameEntity( const entity_info& info )
+    {
+        // Check that the entity info contains a transform
+        // which all entities must have
+        assert( info.transform );
+        if ( !info.transform )
+        {
+            // Return a default entity (ie invalid)
+            return {};
+        }
+
+        entity_id id;
+
+        // Check if we should reuse slots or create new slots
+        if ( freeIds.size() > id::min_deleted_elements )
+        {
+            // Reusing available slots
+            id = freeIds.front();
+            assert( !isAlive( entity( id ) ) );
+            freeIds.pop_front();
+            id = entity_id{ id::newGeneration( id ) };
+            ++generations[ id::index( id ) ];
+            //generations[ id::index( id ) ];
+        }
+        else 
+        {
+            // Add new slots
+            id = entity_id{ (id::id_type)generations.size() };
+            generations.push_back( 0 );
+            // Why not use emplace_back here?
+            //generations.emplace_back( id );
+
+            // Resize components
+            // NOTE(klek): Here we call emplace_back instead of resize()
+            //             to keep the number of memory allocations low
+            transforms.emplace_back();
+        }
+
+        const entity newEntity{ id };
+        const id::id_type index{ id::index(id) };
+
+        // Create transform compontent
+        assert( !transforms[ index ].isValid() );
+        transforms[ index ] = transform::createTransform( *info.transform, 
+                                                           newEntity );
+        if ( !transforms[ index ].isValid() )
+        {
+            // Return a default entity (ie invalid)
+            return {};
+        }
+
+        return newEntity;
+    }
+
+    void removeGameEntity( entity e )
+    {
+        const entity_id id{ e.getId() };
+        const id::id_type index{ id::index( id ) };
+        // Check that this entity is alive
+        assert( isAlive(e) );
+        if ( isAlive(e) )
+        {
+            // Remove transforms
+            transform::removeTransform( transforms[ index ] );
+            // Replace the slot with a default component (ie invalid)
+            transforms[ index ] = {};
+            freeIds.push_back( id );
+        }
+    }
+
+    bool isAlive( entity e )
+    {
+        // DEBUG: Check that the entity is valid
+        assert( e.isValid() );
+        const entity_id id{ e.getId() };
+        const id::id_type index{ id::index( id ) };
+        // DEBUG: Check that index is withing the size of generations
+        assert( index < generations.size() );
+        // DEBUG: Check that the current generation is as expected
+        //assert( generations[ index ] == id::generation( id ) );
+
+        // If the current generation for this index is equal to the expected
+        // generation and the transform for this entity is valid, then this 
+        // entity is alive
+        return ( generations[ index ] == id::generation( id ) && 
+                 transforms[ index ].isValid()                  );
+    }
+
+    transform::component entity::getTransform() const
+    {
+        // DEBUG: Check that the entity is valid
+        assert( isAlive( *this ) );
+        const id::id_type index{ id::index( m_Id ) };
+        return transforms[ index ];
+    }
+
+} // namespace muggy::entity

--- a/muggy/code/components/entity.h
+++ b/muggy/code/components/entity.h
@@ -1,0 +1,43 @@
+//********************************************************************
+//  File:    entity.h
+//  Date:    Fri, 24 Nov 2023: 20:28
+//  Version: 
+//  Author:  klek
+//  Notes:   
+//********************************************************************
+
+#if !defined(ENTITY_H)
+#define ENTITY_H
+
+#include "componentsCommon.h"
+
+namespace muggy
+{
+    // ***************************************************************
+    // Forward declaration of the transforms init_info
+    namespace transform
+    {
+        struct init_info;
+    } // namespace transform
+    // ***************************************************************
+
+    namespace game_entity
+    {
+        struct entity_info
+        {
+            // should contain a transform
+            transform::init_info* transform{ nullptr };
+        };
+    
+        entity createGameEntity( const entity_info& info );
+        void removeGameEntity( entity e );
+        bool isAlive( entity e );
+
+    } // namespace game_entity
+    
+    
+
+} // namespace muggy
+
+
+#endif

--- a/muggy/code/components/transform.cpp
+++ b/muggy/code/components/transform.cpp
@@ -1,0 +1,73 @@
+//********************************************************************
+//  File:    transform.cpp
+//  Date:    Fri, 24 Nov 2023: 22:29
+//  Version: 
+//  Author:  klek
+//  Notes:   
+//********************************************************************
+
+#include "transform.h"
+#include "entity.h"
+
+namespace muggy::transform
+{
+    namespace
+    {
+        utils::vector<math::fv3d>             positions;
+        utils::vector<math::fv4d>             rotations;
+        utils::vector<math::fv3d>             scales;
+    } // namespace anonymous
+    
+    component createTransform( const init_info& info, game_entity::entity e )
+    {
+        // DEBUG: Check that the entity is valid!
+        assert( e.isValid() );
+        const id::id_type e_index{ id::index( e.getId() ) };
+
+        // Check if we should reuse slots or create new slots
+        if ( positions.size() > e_index )
+        {
+            // Reusing available slots
+            positions[ e_index ] = math::fv3d( info.position );
+            rotations[ e_index ] = math::fv4d( info.rotation );
+            scales[ e_index ] = math::fv3d( info.scale );
+        }
+        else 
+        {
+            // Add new slots
+            assert( positions.size() == e_index );
+            positions.emplace_back( info.position );
+            rotations.emplace_back( info.rotation );
+            scales.emplace_back( info.scale );
+        }
+
+        return component( transform_id{ (id::id_type)positions.size() - 1 } );
+    }
+
+    void removeTransform( component c )
+    {
+        assert( c.isValid() );
+    }
+
+    math::fv3d component::getPosition() const
+    {
+        // DEBUG: Check that this component is valid
+        assert( isValid() );
+        return positions[ id::index( m_Id )];
+    }
+
+    math::fv4d component::getRotation() const
+    {
+        // DEBUG: Check that this component is valid
+        assert( isValid() );
+        return rotations[ id::index( m_Id )];
+    }
+
+    math::fv3d component::getScale() const
+    {
+        // DEBUG: Check that this component is valid
+        assert( isValid() );
+        return scales[ id::index( m_Id )];
+    }
+
+} // namespace muggy::transform

--- a/muggy/code/components/transform.h
+++ b/muggy/code/components/transform.h
@@ -1,0 +1,32 @@
+//********************************************************************
+//  File:    transform.h
+//  Date:    Fri, 24 Nov 2023: 21:01
+//  Version: 
+//  Author:  klek
+//  Notes:   
+//********************************************************************
+
+#if !defined(TRANSFORM_H)
+#define TRANSFORM_H
+
+#include "componentsCommon.h"
+
+namespace muggy::transform
+{
+    struct init_info
+    {
+        // Position in x, y, z
+        float position[3];
+        // Rotation in x, y, z, w (Quaternion)
+        float rotation[4]{ };
+        // Scale in x, y, z
+        float scale[3]{ 1.0f, 1.0f, 1.0f };
+    };
+
+    component createTransform( const init_info& info, 
+                               game_entity::entity entity );
+    void removeTransform( component c );
+} // namespace muggy::transform
+
+
+#endif

--- a/muggy/engineAPI/componentTransform.h
+++ b/muggy/engineAPI/componentTransform.h
@@ -1,0 +1,36 @@
+//********************************************************************
+//  File:    componentTransform.h
+//  Date:    Fri, 24 Nov 2023: 22:20
+//  Version: 
+//  Author:  klek
+//  Notes:   
+//********************************************************************
+
+#if !defined(COMPONENT_TRANSFORM_H)
+#define COMPONENT_TRANSFORM_H
+
+#include "../code/components/componentsCommon.h"
+
+namespace muggy::transform
+{
+    DEFINE_TYPED_ID(transform_id);
+
+    class component final
+    {
+    public:
+        constexpr explicit component( transform_id id ) : m_Id( id ) {}
+        constexpr component( ) : m_Id( id::invalid_id ) {}
+        constexpr transform_id getId( ) const { return m_Id; }
+        constexpr bool isValid( ) const { return id::isValid( m_Id ); }
+
+        math::fv3d getPosition() const;
+        math::fv4d getRotation() const;
+        math::fv3d getScale() const;
+
+    private:
+        transform_id m_Id;
+    };
+} // namespace muggy::transform
+
+
+#endif

--- a/muggy/engineAPI/gameEntity.h
+++ b/muggy/engineAPI/gameEntity.h
@@ -1,0 +1,34 @@
+//********************************************************************
+//  File:    gameEntity.h
+//  Date:    Fri, 24 Nov 2023: 21:29
+//  Version: 
+//  Author:  klek
+//  Notes:   
+//********************************************************************
+
+#if !defined(GAME_ENTITY_H)
+#define GAME_ENTITY_H
+
+#include "../code/components/componentsCommon.h"
+#include "componentTransform.h"
+
+namespace muggy::game_entity
+{
+    DEFINE_TYPED_ID(entity_id);
+
+    class entity
+    {
+    public:
+        constexpr explicit entity( entity_id id ) : m_Id( id ) {}
+        constexpr entity( ) : m_Id( id::invalid_id ) {}
+        constexpr entity_id getId( ) const { return m_Id; }
+        constexpr bool isValid( ) const { return id::isValid( m_Id ); }
+
+        transform::component getTransform() const;
+    private:
+        entity_id m_Id;
+    };
+} // namespace muggy::game_entity
+
+
+#endif

--- a/muggyExample/tests/test.h
+++ b/muggyExample/tests/test.h
@@ -12,7 +12,8 @@
 #include <thread>
 
 // Defines for test to run
-#define TEST_WINDOW             1
+#define TEST_ENTITIES           1
+#define TEST_WINDOW             0
 
 class test
 {

--- a/muggyExample/tests/testEntities.cpp
+++ b/muggyExample/tests/testEntities.cpp
@@ -1,0 +1,96 @@
+//********************************************************************
+//  File:    testEntities.cpp
+//  Date:    Sat, 25 Nov 2023: 00:58
+//  Version: 
+//  Author:  klek
+//  Notes:   
+//********************************************************************
+
+#include "test.h"
+#if TEST_ENTITIES
+#include "testEntities.h"
+
+#include <iostream>
+#include <ctime>
+
+//#if TEST_ENTITIES
+
+using namespace muggy;
+
+bool engineTest::initialize( void ) 
+{
+    srand( (uint32_t)time( nullptr ) );
+    return true;
+}
+
+void engineTest::run ( void ) 
+{
+    do 
+    {
+        for ( uint32_t i = 0; i < 10000; i++ )
+        {
+            createRandom();
+            removeRandom();
+            m_TotalEntities = (uint32_t)m_Entities.size();
+        }
+        printResults();
+    } while ( getchar() != 'q' );
+    
+}
+
+void engineTest::shutdown( void ) 
+{
+
+}
+
+void engineTest::createRandom( void )
+{
+    uint32_t count = rand() % 20;
+
+    if ( m_Entities.empty() )
+    {
+        count = 1000;
+    }
+
+    transform::init_info transformInfo{};
+    game_entity::entity_info entityInfo { &transformInfo };
+
+    while ( count > 0 )
+    {
+        m_Added++;
+        game_entity::entity e{ game_entity::createGameEntity(entityInfo) };
+        assert( e.isValid() && id::isValid( e.getId() ) );
+        m_Entities.push_back( e );
+        assert( game_entity::isAlive( e ) );
+        count--;
+    }
+}
+
+void engineTest::removeRandom( void )
+{
+    uint32_t count = rand() % 20;
+
+    if ( m_Entities.size() < 1000 ) return;
+    while ( count > 0 )
+    {
+        const uint32_t index{ (uint32_t)rand() % (uint32_t)m_Entities.size() };
+        const game_entity::entity e{ m_Entities[ index ] };
+        assert( e.isValid() && id::isValid( e.getId() ) );
+        if ( e.isValid() )
+        {
+            game_entity::removeGameEntity(e);
+            m_Entities.erase( m_Entities.begin() + index );
+            assert( !game_entity::isAlive( e ) );
+            m_Removed++;
+        }
+        count--;
+    }
+}
+
+void engineTest::printResults()
+{
+    std::cout << "Entities created: " << m_Added << "\n";
+    std::cout << "Entities deleted: " << m_Removed << "\n";
+}
+
+#endif

--- a/muggyExample/tests/testEntities.h
+++ b/muggyExample/tests/testEntities.h
@@ -1,0 +1,45 @@
+//********************************************************************
+//  File:    testEntities.h
+//  Date:    Sat, 25 Nov 2023: 00:55
+//  Version: 
+//  Author:  klek
+//  Notes:   
+//********************************************************************
+
+#if !defined(TEST_ENTITIES_H)
+#define TEST_ENTITIES_H
+
+#include "test.h"
+//#include "muggy.h"
+#include "../../muggy/code/common/common.h"
+#include "../../muggy/code/components/entity.h"
+#include "../../muggy/code/components/transform.h"
+
+class engineTest : public test
+{
+public:
+    bool initialize( void ) override;
+    void run ( void ) override;
+    void shutdown( void ) override;
+
+    // Additional functions for this test
+
+private:
+    void createRandom();
+    void removeRandom();
+    void printResults();
+
+    bool m_IsRunning = true;
+    // Need a vector for storing entities
+    muggy::utils::vector<muggy::game_entity::entity> m_Entities;
+    // Need a variable to keep track of added entities
+    uint32_t m_Added = 0;
+    // Need a variable to keep track of removed entities
+    uint32_t m_Removed = 0;
+    // Need a variable to keep track of total number of entitites
+    uint32_t m_TotalEntities = 0;
+};
+
+
+
+#endif


### PR DESCRIPTION
This introduces and adds the game_entity to the engine. A game_entity describes essentially any entity in the engine (camera, NPC, tree/stone, player etc) and can have different components. A game_entity always has an ID based on the id-header indexing system and it also always has a transform component. This transform component is also added via this commit.
The functionality has been tested on both Linux via WSL: Ubuntu and on Windows 10 with the desired and expected functionality.